### PR TITLE
避免使用豆瓣时报 initUserAttributes 未实现错误

### DIFF
--- a/DoubanAuth.php
+++ b/DoubanAuth.php
@@ -73,5 +73,12 @@ class DoubanAuth extends OAuth2 implements IAuth {
         $headers[] = 'Authorization: Bearer ' . $accessToken->getToken();
         return $this->apiInternal($accessToken, $url, $method, $params, $headers);
     }
+    
+    /** 
+     *
+     * @ineritdoc
+     */
+    protected function initUserAttributes() {
+    }
 
 }


### PR DESCRIPTION
yii\authclient\BaseClient::initUserAttributes 217-224 
    /** 
     * Initializes authenticated user attributes.
     * @return array auth user attributes.
     */
    protected function initUserAttributes()
    {   
        throw new NotSupportedException('Method "' . get_class($this) . '::' . __FUNCTION__ . '" not implemented.');
    }